### PR TITLE
Add support for sending raw byte arrays

### DIFF
--- a/js/BluetoothTerminal.js
+++ b/js/BluetoothTerminal.js
@@ -180,6 +180,31 @@ class BluetoothTerminal {
   }
 
   /**
+   * Send raw byte data to the connected device.
+   * @param {string} data - Data. Must be an Uint8Array.
+   * @return {Promise} Promise which will be fulfilled when data will be sent or
+   *                   rejected if something went wrong
+   */
+  sendBytes(data) {
+    // Return rejected promise immediately if data is empty.
+    if (!data) {
+      return Promise.reject('Data must be not empty');
+    }
+
+    // Return rejected promise immediately if data is not an Uint8Array.
+    if (!(data instanceof Uint8Array)) {
+      throw new Error('Data type is not an Uint8Array');
+    }
+
+    // Return rejected promise immediately if there is no connected device.
+    if (!this._characteristic) {
+      return Promise.reject('There is no connected device');
+    }
+
+    return this._characteristic.writeValue(data);
+  }
+
+  /**
    * Get the connected device name.
    * @return {string} Device name or empty string if not connected
    */

--- a/js/BluetoothTerminal.js
+++ b/js/BluetoothTerminal.js
@@ -193,7 +193,7 @@ class BluetoothTerminal {
 
     // Return rejected promise immediately if data is not an Uint8Array.
     if (!(data instanceof Uint8Array)) {
-      throw new Error('Data type is not an Uint8Array');
+      return Promise.reject('Data type is not an Uint8Array');
     }
 
     // Return rejected promise immediately if there is no connected device.


### PR DESCRIPTION
For a project, I have to support a protocol which uses raw bytes for communication. I found it to be nearly impossible to do this with the existing "send" method as it does some character set encoding magic. So I've added a new method which can be used to send raw byte arrays.