### PR TITLE
Fixed direct link for BluetoothTerminal class

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ command.
 ### BluetoothTerminal.js API
 
 Also, you can install [bluetooth-terminal](https://github.com/1oginov/bluetooth-terminal) package or
-[directly download the file](https://raw.githubusercontent.com/1oginov/bluetooth-terminal/master/BluetoothTerminal.js)
+[directly download the file](https://raw.githubusercontent.com/1oginov/bluetooth-terminal/master/src/BluetoothTerminal.js)
 containing `BluetoothTerminal` class written in ES6 and use it as you want. Here is a simple code snippet that can be
 helpful for a quick start:
 


### PR DESCRIPTION
The file was put inside a folder named "src" since the last edit on this readme.